### PR TITLE
Allow passing timestamp to congestion endpoint

### DIFF
--- a/endpoint/congestion-rates.js
+++ b/endpoint/congestion-rates.js
@@ -2,6 +2,7 @@
 
 const NodeCache = require('node-cache');
 const statusCodes = require('http-status-codes');
+const moment = require('moment-timezone');
 const tripCongestionRateProvider = require('../service/trip-congestion-rate-provider');
 
 const congestionRatesCache = new NodeCache({
@@ -15,10 +16,10 @@ router.get('/trips/:tripId/congestionRate', async function (req, res) {
     const { tripId } = req.params;
     const { timestamp: timestampStr } = req.query;
 
-    const timestamp = timestampStr ? new Date(timestampStr) : null;
+    const timestamp = timestampStr ? moment(timestampStr) : moment();
 
     try {
-        const congestionRate = congestionRatesCache.get([tripId, timestamp].join(''))
+        const congestionRate = congestionRatesCache.get([tripId, timestamp.toString()].join(''))
             || await getTripCongestionRate(tripId, timestamp);
 
         res.status(statusCodes.OK).json(congestionRate);
@@ -41,7 +42,7 @@ async function getTripCongestionRate(tripId, timestamp) {
         congestionRate = null;
     }
 
-    congestionRatesCache.set([tripId, timestamp].join(''), congestionRate);
+    congestionRatesCache.set([tripId, timestamp.toString()].join(''), congestionRate);
 
     return congestionRate;
 }

--- a/endpoint/congestion-rates.js
+++ b/endpoint/congestion-rates.js
@@ -43,9 +43,7 @@ async function getTripCongestionRate(tripId, timestamp) {
 
     congestionRatesCache.set([tripId, timestamp].join(''), congestionRate);
 
-
     return congestionRate;
-
 }
 
 module.exports = router;

--- a/endpoint/congestion-rates.js
+++ b/endpoint/congestion-rates.js
@@ -27,8 +27,6 @@ router.get('/trips/:tripId/congestionRate', async function (req, res) {
         console.error(e);
         res.status(statusCodes.INTERNAL_SERVER_ERROR).json({});
     }
-
-
 });
 
 async function getTripCongestionRate(tripId, timestamp) {

--- a/service/load-duration-provider.js
+++ b/service/load-duration-provider.js
@@ -79,7 +79,6 @@ module.exports = {
  * @returns {number} Passenger load time in seconds
  */
 function sumLoadDurationFromTimestampsLog(timestampsLog) {
-
     return timestampsLog
         .filter(removeAdjacentDuplicateTimestampsFilter)
         .reduce(groupTimestampsByDoorStatusIntervalReducer, [])
@@ -205,7 +204,6 @@ function getTimestampsLogByTrip(stopId, tripId, timestamp) {
     }
 
     return db().models.TripStop.findAll({
-        logging: null,
         attributes: ['tripId', 'doorsOpen', 'seenAtStop'],
         where: whereCondition,
         order: [

--- a/service/load-duration-provider.js
+++ b/service/load-duration-provider.js
@@ -193,7 +193,6 @@ function sumDoorStatusDurationsReducer(totalDurationInSeconds, doorStatusDuratio
  */
 function getTimestampsLogByTrip(stopId, tripId, timestamp) {
     return db().models.TripStop.findAll({
-        logging: true,
         attributes: ['tripId', 'doorsOpen', 'seenAtStop'],
         where: {
             stopId,

--- a/service/trip-congestion-rate-provider.js
+++ b/service/trip-congestion-rate-provider.js
@@ -20,11 +20,12 @@ module.exports = {
      * There is no upper limit for the congestion rate.
      *
      * @param {String} tripId
+     * @param {Date} timestamp
      * @returns {Promise<number>}
      * @throws RoutePatternAverageDurationNotFoundError
      */
-    async getCongestionRate(tripId) {
-        const loadDurations = await getLoadDurations(tripId);
+    async getCongestionRate(tripId, timestamp) {
+        const loadDurations = await getLoadDurations(tripId, timestamp);
 
         const weightedLoadDuration = loadDurations
             .reduce((acc, loadDurations, idx, arr) => {
@@ -55,9 +56,10 @@ module.exports = {
  * sorted by chronological order (eg. 1st stop on route is 1st in array)
  *
  * @param {String} tripId
+ * @param {Date} timestamp
  * @returns {Array<Array<Number, Number>>}
  */
-async function getLoadDurations(tripId) {
+async function getLoadDurations(tripId, timestamp) {
     try {
         const [trip, stopsBeenTo] = await Promise.all([
             tripRepository.getById(tripId),
@@ -66,8 +68,8 @@ async function getLoadDurations(tripId) {
 
         return await Promise.all(
             stopsBeenTo.map(stop => Promise.all([
-                loadDurationProvider.getByTrip(stop.id, tripId),
-                loadDurationProvider.getAverageByRoutePattern(stop.id, trip.routePatternId),
+                loadDurationProvider.getByTrip(stop.id, tripId, timestamp),
+                loadDurationProvider.getAverageByRoutePattern(stop.id, trip.routePatternId, timestamp),
             ]))
         );
     } catch (e) {


### PR DESCRIPTION
With the timestamp flag you can find out the congestion rate
for a trip at any given point in time. Previously you could only get the
latest value.